### PR TITLE
Gem change

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,9 +66,9 @@ group :development do
   gem "error_highlight", ">= 0.4.0", platforms: [:ruby]
 end
 
-  group :production do
-    gem 'pg','0.20.0'
-  end
+group :production do
+  gem 'pg', '~> 1.1'
+end
 
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,7 +172,7 @@ GEM
     nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
     os (1.1.4)
-    pg (0.20.0)
+    pg (1.5.6)
     prism (0.24.0)
     psych (5.1.2)
       stringio
@@ -293,7 +293,7 @@ DEPENDENCIES
   googleauth
   importmap-rails
   jbuilder
-  pg (= 0.20.0)
+  pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.1)
   rqrcode


### PR DESCRIPTION
## 背景
`heroku run rails db:migrate`でエラーが発生したため、pg gemのバージョンを上げる。